### PR TITLE
Compiles for both Main files + documentation on repo's frontpage.

### DIFF
--- a/Cpp/NAOH21/Main.cpp
+++ b/Cpp/NAOH21/Main.cpp
@@ -19,13 +19,13 @@ int main(){
 	joints[L_ARM+SHOULDER_ROLL]=M_PI_4;
 	joints[L_ARM+ELBOW_YAW]=0;
 	joints[L_ARM+ELBOW_ROLL]=0;
-	joints[L_ARM+WRIST_YAW]=0;
+	//joints[L_ARM+WRIST_YAW]=0;
 	//Right Hand
 	joints[R_ARM+SHOULDER_PITCH]=M_PI_2;
 	joints[R_ARM+SHOULDER_ROLL]=-M_PI_4;
 	joints[R_ARM+ELBOW_YAW]=0;
 	joints[R_ARM+ELBOW_ROLL]=0;
-	joints[R_ARM+WRIST_YAW]=0;
+	//joints[R_ARM+WRIST_YAW]=0;
 	//Left Leg
 	joints[L_LEG+HIP_YAW_PITCH]=-M_PI_4;
 	joints[L_LEG+HIP_ROLL]=0;

--- a/Cpp/NAOH25/robotConsts.h
+++ b/Cpp/NAOH25/robotConsts.h
@@ -1,0 +1,42 @@
+/**
+ * robot_consts.h
+ *
+ *  Created on: Dec 9, 2010
+ *      Author: trs
+ */
+
+#ifndef ROBOT_CONSTS_H_
+#define ROBOT_CONSTS_H_
+#include <vector>
+#include <map>
+#include <string>
+
+namespace KDeviceLists
+{
+	enum ChainHeadNames
+	{
+	    YAW = 0, PITCH, HEAD_SIZE
+	};
+
+	enum ChainArmNames
+	{
+	    SHOULDER_PITCH = 0, SHOULDER_ROLL, ELBOW_YAW, ELBOW_ROLL, WRIST_YAW, HAND, ARM_SIZE
+	};
+
+	enum ChainLegNames
+	{
+	    HIP_YAW_PITCH = 0, HIP_ROLL, HIP_PITCH, KNEE_PITCH, ANKLE_PITCH, ANKLE_ROLL, LEG_SIZE
+	};
+
+	enum ChainsNames
+	{
+		CHAIN_HEAD = 0, CHAIN_L_ARM, CHAIN_L_LEG, CHAIN_R_LEG,CHAIN_R_ARM, CHAINS_SIZE
+	};
+
+	enum JointNames
+	{
+	    HEAD = 0, L_ARM = HEAD_SIZE, L_LEG = L_ARM + ARM_SIZE, R_LEG = L_LEG + LEG_SIZE, R_ARM = R_LEG + LEG_SIZE, NUMOFJOINTS = R_ARM + ARM_SIZE
+
+	};
+};
+#endif /* ROBOT_CONSTS_H_ */

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 NAOKinematics
 =============
 
-Forward and Inverse Kinematics for the NAO robot in C++
+Forward and Inverse Kinematics solver for the NAO robot in C++.  Details about the library can be found in the following two documents:
+
+ * Kofinas N., Orfanoudakis E., Lagoudakis M.: [Complete Analytical Inverse Kinematics for NAO](http://www.nikofinas.com/Publications/Complete_Analytical_Inverse_Kinematics_for_NAO.pdf), Proceedings of the 13th International Conference on Autonomous Robot Systems and Competitions (ROBOTICA), Lisbon, Portugal, April 2013, pp. 1-6.
+ *  Kofinas N.: [Forward and Inverse Kinematics for the NAO Humanoid Robot](http://www.nikofinas.com/Projects/KofinasThesis.pdf), Diploma Thesis, Department of Electronic and Computer Engineering, Technical University of Crete, July 2012.
 
 Main.cpp file is only for demonstration.


### PR DESCRIPTION
Both Main files did not compile, for different reasons:
- `NAOH21/Main.cpp` did not compile, because `WRIST_YAW` was used, while commented in its `robotConsts.h`; 
- `NAOH25/Main.cpp` did not compile, because `robotConsts.h` was lacking. I uncommented the `WRIST_YAW` and `HAND` enum values.
