### PR TITLE
Fix for Issue #2 the HandOffsetZ value is negative in Z axis

### DIFF
--- a/Cpp/NAOH21/NAOKinematics.cpp
+++ b/Cpp/NAOH21/NAOKinematics.cpp
@@ -35,7 +35,7 @@ NAOKinematics::	NAOKinematics() :T(FR_SIZE),Tjacobian(FR_SIZE),joints(FR_SIZE),c
 	//End and Base effectors
 	KMatTransf::makeTranslation(T[FR_BASE_T+CHAIN_R_ARM], 0.0, -(ShoulderOffsetY), ShoulderOffsetZ);
 	KMatTransf::makeRotationXYZ(T[FR_END_T+CHAIN_R_ARM], 0.0, 0.0, -PI_2);
-	KMatTransf::makeTranslation(t1, (HandOffsetX + LowerArmLength),0.0,HandOffsetZ );
+	KMatTransf::makeTranslation(t1, (HandOffsetX + LowerArmLength),0.0,-HandOffsetZ );
 	T[FR_END_T+CHAIN_R_ARM]*=t1;
 	
 	//CoM coordinates

--- a/Cpp/NAOH25/NAOKinematics.cpp
+++ b/Cpp/NAOH25/NAOKinematics.cpp
@@ -38,7 +38,7 @@ NAOKinematics::	NAOKinematics() :T(FR_SIZE),Tjacobian(FR_SIZE),joints(FR_SIZE),c
 	//This is the correct
 	//KMatTransf::makeTranslation(t1, HandOffsetX,0.0,HandOffsetZ );
 	//THIS is the fix
-	KMatTransf::makeTranslation(t1, LowerArmLength+HandOffsetX,0.0,HandOffsetZ );
+	KMatTransf::makeTranslation(t1, LowerArmLength+HandOffsetX,0.0,-HandOffsetZ );
 	T[FR_END_T+CHAIN_R_ARM]*=t1;
 	
 	//CoM coordinates


### PR DESCRIPTION
When comparing the nao forward kinematics results of this library and those from naoqi, I noticed an error in the Z axis value.
According to the aldebaran documentation HandOffsetZ is negative in the z axis. So I changed the code accordingly, and the bug was fixed.

After fixing the bug:

x = 218.7 y = 113 z = 87.69
x = 218.7 y = -113 z = 87.69

Naoqi output for the Left arm in the same configuration in meters:

x = 0.21852196753025055,
y = 0.11063870042562485,
z = 0.08774302154779434,
